### PR TITLE
removed jarring switch when fetching for neo status

### DIFF
--- a/app/components/ShapeShift.js
+++ b/app/components/ShapeShift.js
@@ -40,8 +40,8 @@ class ShapeShift extends Component {
 	}
 
 	render() {
-		const { available, fetching, stage, txData, completeData, resetOrderState } = this.props;
-		if (!available && !fetching && !stage) return <UnavailableExchange exchangeName={"ShapeShift"}/>;
+		const { available, stage, txData, completeData, resetOrderState } = this.props;
+		if (!available && !stage) return <UnavailableExchange exchangeName={"ShapeShift"}/>;
 		else if (!stage) return <Exchange_OrderForm {...this.props} />;
 		else if (stage === "ordering") return <Exchange_OrderLoading exchangeName={"ShapeShift"}/>;
 		else if (stage === "depositing") return <Exchange_Deposit txData={txData} exchangeName={"shapeshift"}/>;

--- a/app/components/UnavailableExchange.js
+++ b/app/components/UnavailableExchange.js
@@ -1,17 +1,17 @@
 import React from "react";
 
 export default function UnavailableExchange(props)  {
-	const {exchangeName} = props;
+	const { exchangeName } = props;
 	return  (
 		<div className="dash-panel fadeInDown">
 			<div className="com-soon row fadeInDown center">
 				<div id="preloader">
 					<div id="loader"></div>
 				</div>
-				<h1 className="top-20">{exchangeName} not available</h1>
+				<h1 className="top-20">{ exchangeName } not available</h1>
 				<div className="col-xs-10 col-xs-offset-1">
 					<h4 className="top-20 lineheight-up">
-            We apologise but our exchange partner {exchangeName} currently does not have NEO available. Please try again soon.
+						We apologise but our exchange partner {exchangeName} currently does not have NEO available. Please try again soon.
 					</h4>
 				</div>
 				<div className="clear-both" />


### PR DESCRIPTION
User story: As a user, the order screen for ShapeShift exchange does not flash when it is fetching for NEO availability.

Implementation: Previously, UnavailableExchange will not render when NEO availability is being fetched. Removed the fetching boolean in the conditional statement so it only stops being rendered if there is NEO availability rather than stop being rendered during a split second fetch.