### PR TITLE
Shapeshift dev mode memory consumption bug fix

### DIFF
--- a/app/store/configureStore.js
+++ b/app/store/configureStore.js
@@ -13,7 +13,7 @@ if (process.env.NODE_ENV === "production") {
 } else {
 	enhancer = compose(
 		applyMiddleware(thunk),
-		DevTools.instrument()
+		DevTools.instrument({ maxAge: 50 })
 	);
 }
 


### PR DESCRIPTION
User story: As a developer, the ShapeShift screen does not freeze or slow down after time.

Implementation: Added a maxAge of 50 for Redux Devtools. Any actions older later than the last 50 actions gets deleted so memory is not continuously allocated.